### PR TITLE
net: mvpp2x: change driver name to avoid registration error

### DIFF
--- a/drivers/net/ethernet/marvell/mvpp2x/mv_pp2x.h
+++ b/drivers/net/ethernet/marvell/mvpp2x/mv_pp2x.h
@@ -26,7 +26,7 @@
 #include "mv_pp2x_hw_type.h"
 #include "mv_gop110_hw_type.h"
 
-#define MVPP2_DRIVER_NAME "mvpp2"
+#define MVPP2_DRIVER_NAME "mvpp2x"
 #define MVPP2_DRIVER_VERSION "1.0"
 
 #define MVPP2X_SKB_MAGIC_MASK		0xFFFFFFC0


### PR DESCRIPTION
In case both mvpp2 and mvpp2x are compiled into the kernel during boot
one will get following error from driver_register():

Error: Driver 'mvpp2' is already registered, aborting..

That happens because both drivers have name set to 'mvpp2'.
This patch fixes that by changing mvpp2x driver's name to 'mvpp2x'.

Signed-off-by: Tomasz Duszynski <tdu@semihalf.com>