### PR TITLE
fix: usb: ehci-orion: don't compile PM functions without CONFIG_PM

### DIFF
--- a/drivers/usb/host/ehci-orion.c
+++ b/drivers/usb/host/ehci-orion.c
@@ -362,6 +362,8 @@ static int ehci_orion_drv_remove(struct platform_device *pdev)
 	return 0;
 }
 
+#ifdef	CONFIG_PM
+
 static int ehci_orion_drv_suspend(struct platform_device *pdev,
 				  pm_message_t state)
 {
@@ -454,6 +456,8 @@ static int ehci_orion_drv_resume(struct platform_device *pdev)
 
 	return 0;
 }
+
+#endif
 
 static void ehci_orion_drv_shutdown(struct platform_device *pdev)
 {


### PR DESCRIPTION
This commit fixes the compilation when CONFIG_PM isn't enabled. Otherwise, ehci_suspend and ehci_resume functions are called but they are not defined -> implicit declaration of function 'ehci_suspend'